### PR TITLE
Feature/add configure secure redirect exempt

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -114,7 +114,8 @@ STATIC_URL = "static/"
 
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
-
 MESSAGE_TAGS = {
     message_constants.ERROR: "danger",  # Bootstrap error class
 }
+
+SECURE_REDIRECT_EXEMPT = [r"^health\/$"]

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,6 +16,9 @@ Including another URLconf
 
 from django.urls import include, path
 
+from . import views
+
 urlpatterns = [
     path("", include("sepacetamol.urls")),
+    path("health/", views.HealthCheckView.as_view(), name="health"),
 ]

--- a/config/views.py
+++ b/config/views.py
@@ -1,0 +1,7 @@
+from django.http import JsonResponse
+from django.views import View
+
+
+class HealthCheckView(View):
+    def get(self, request, *args, **kwargs):
+        return JsonResponse({"status": "pass"})


### PR DESCRIPTION
In order to make health check request pass within our AWS infrastructure, the health check endpoint needs to be exempted from https redirect.